### PR TITLE
Fix typo in include guard in keyboard_helper.h

### DIFF
--- a/examples/host/cdc_msc_hid/src/keyboard_helper.h
+++ b/examples/host/cdc_msc_hid/src/keyboard_helper.h
@@ -1,5 +1,5 @@
 #ifndef KEYBOARD_HELPER_H
-#define KEYBAORD_HELPER_H
+#define KEYBOARD_HELPER_H
 
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
A typo in the include guard rendered it non-functional.
Updated the #define'd symbol to match the #ifndef guard