### PR TITLE
Mark `in_isr` as unused in osal_pico.h

### DIFF
--- a/src/osal/osal_pico.h
+++ b/src/osal/osal_pico.h
@@ -59,6 +59,8 @@ static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semde
 
 static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
 {
+  (void) in_isr;
+
   sem_release(sem_hdl);
   return true;
 }
@@ -161,6 +163,8 @@ static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
 
 static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
+  (void) in_isr;
+
   // TODO: revisit... docs say that mutexes are never used from IRQ context,
   //  however osal_queue_recieve may be. therefore my assumption is that
   //  the fifo mutex is not populated for queues used from an IRQ context

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -39,6 +39,8 @@ static inline void _hw_endpoint_lock_update(struct hw_endpoint *ep, int delta) {
     // todo add critsec as necessary to prevent issues between worker and IRQ...
     //  note that this is perhaps as simple as disabling IRQs because it would make
     //  sense to have worker and IRQ on same core, however I think using critsec is about equivalent.
+    (void) ep;
+    (void) delta;
 }
 
 static inline void _hw_endpoint_update_last_buf(struct hw_endpoint *ep)


### PR DESCRIPTION
This prevents the following warning when building with -Wextra:

```C
In file included from [redacted]/pico-sdk/lib/tinyusb/src/osal/osal.h:57,
                 from [redacted]/pico-sdk/lib/tinyusb/src/tusb.h:38,
                 from [redacted]/pico-sdk/lib/tinyusb/src/device/usbd.c:31:
[redacted]/pico-sdk/lib/tinyusb/src/osal/osal_pico.h: In function 'osal_semaphore_post':
[redacted]/pico-sdk/lib/tinyusb/src/osal/osal_pico.h:60:71: error: unused parameter 'in_isr' [-Werror=unused-parameter]
   60 | static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
      |                                                                       ^
In file included from [redacted]/pico-sdk/lib/tinyusb/src/osal/osal.h:57,
                 from [redacted]/pico-sdk/lib/tinyusb/src/tusb.h:38,
                 from [redacted]/pico-sdk/lib/tinyusb/src/device/usbd.c:31:
[redacted]/pico-sdk/lib/tinyusb/src/osal/osal_pico.h: In function 'osal_queue_send':
[redacted]/pico-sdk/lib/tinyusb/src/osal/osal_pico.h:162:79: error: unused parameter 'in_isr' [-Werror=unused-parameter]
  162 | static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
      |
```

Casting unused arguments to `void` is how unused parameters are dealt with in the rest of the tinyusb codebase